### PR TITLE
Replace !succeeded with failed for better readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Triplets.Kernel/issues/9
-Your prepared branch: issue-9-516686bb
-Your prepared working directory: /tmp/gh-issue-solver-1757789681167
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Triplets.Kernel/issues/9
+Your prepared branch: issue-9-516686bb
+Your prepared working directory: /tmp/gh-issue-solver-1757789681167
+
+Proceed.

--- a/Platform.Data.Triplets.Kernel/PersistentMemoryManager.c
+++ b/Platform.Data.Triplets.Kernel/PersistentMemoryManager.c
@@ -612,7 +612,7 @@ signed_integer OpenLinks(char* filename)
 {
     InitPersistentMemoryManager();
     signed_integer result = OpenStorageFile(filename);
-    if (!succeeded(result))
+    if (failed(result))
         return result;
     return SetStorageFileMemoryMapping();
 }
@@ -620,7 +620,7 @@ signed_integer OpenLinks(char* filename)
 signed_integer CloseLinks()
 {
     signed_integer result = ResetStorageFileMemoryMapping();
-    if (!succeeded(result))
+    if (failed(result))
         return result;
     return CloseStorageFile();
 }


### PR DESCRIPTION
## Summary
- Replace two instances of `!succeeded(result)` with `failed(result)` in `PersistentMemoryManager.c`
- Improves code readability while maintaining the same functionality
- Changes are in the `OpenLinks` and `CloseLinks` functions

## Test plan
- [x] Built the project successfully with `make`
- [x] Ran the basic test which passes
- [x] Verified the change is functionally equivalent (`failed(x)` ≡ `!succeeded(x)`)

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #9