### PR TITLE
Fix x86/Win32 build errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Triplets.Kernel/issues/8
+Your prepared branch: issue-8-20e9acc7
+Your prepared working directory: /tmp/gh-issue-solver-1757789912457
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Triplets.Kernel/issues/8
-Your prepared branch: issue-8-20e9acc7
-Your prepared working directory: /tmp/gh-issue-solver-1757789912457
-
-Proceed.

--- a/Platform.Data.Triplets.Kernel/Platform.Data.Triplets.Kernel.vcxproj
+++ b/Platform.Data.Triplets.Kernel/Platform.Data.Triplets.Kernel.vcxproj
@@ -43,7 +43,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -94,7 +94,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CORE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CORE_EXPORTS;LINKS_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <OpenMP>GenerateParallelCode</OpenMP>
       <PreprocessToFile>false</PreprocessToFile>
       <PreprocessKeepComments>false</PreprocessKeepComments>
@@ -145,7 +145,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CORE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CORE_EXPORTS;LINKS_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <OpenMP>GenerateParallelCode</OpenMP>
       <GlobalOptimizations>
       </GlobalOptimizations>
@@ -201,7 +201,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="Common.c" />
     <ClCompile Include="Link.c" />
     <ClCompile Include="PersistentMemoryManager.c" />
     <ClCompile Include="Timestamp.c" />


### PR DESCRIPTION
## 🔧 Fix x86/Win32 Build Errors

This pull request resolves the x86/Win32 build errors identified in issue #8.

### 📋 Issue Reference
Fixes #8

### 🐛 Problems Identified

1. **Missing source file**: The project file referenced a non-existent `Common.c` file in the compilation list
2. **Character set inconsistency**: Win32 Release configuration used Unicode while Win32 Debug used MultiByte character set
3. **Missing preprocessor definitions**: Win32 configurations lacked the `LINKS_DLL` definition needed for proper DLL export handling

### ✅ Solutions Implemented

1. **Removed non-existent file reference**: Removed `Common.c` from the `<ClCompile>` section since only `Common.h` exists
2. **Standardized character set**: Changed Win32 Release configuration from Unicode to MultiByte to match other configurations
3. **Added missing preprocessor definitions**: Added `LINKS_DLL` to both Win32 Debug and Release configurations for consistent DLL export behavior

### 🔍 Technical Details

The changes ensure:
- Consistent build configuration across all platforms (x86/x64, Debug/Release)
- Proper DLL export handling with `LINKS_DLL` definition
- Elimination of compilation errors due to missing source files
- Uniform character set handling across configurations

### 🧪 Verification

The solution aligns with the existing Makefile which also excludes `Common.c` and includes the `LINKS_DLL_EXPORT` definition, confirming the fixes are correct.

---
🤖 Generated with [Claude Code](https://claude.ai/code)