### PR TITLE
Fix formatting: remove extra space before LeftMaintain call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Triplets.Kernel/issues/3
+Your prepared branch: issue-3-bcb6068d
+Your prepared working directory: /tmp/gh-issue-solver-1757823014633
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Triplets.Kernel/issues/3
-Your prepared branch: issue-3-bcb6068d
-Your prepared working directory: /tmp/gh-issue-solver-1757823014633
-
-Proceed.

--- a/Platform.Data.Triplets.Kernel/SizeBalancedTree.h
+++ b/Platform.Data.Triplets.Kernel/SizeBalancedTree.h
@@ -106,7 +106,7 @@ void methodName(elementType* rootIndex, elementType newNodeIndex)               
         if (IsElementLessThanOtherElement(newNodeIndex, *rootIndex))                                                                                                     \
         {                                                                                                                                                                \
             methodName(&GetLeftNode(*rootIndex), newNodeIndex);                                                                                                          \
-             LeftMaintain(rootIndex);                                                                                                                                    \
+            LeftMaintain(rootIndex);                                                                                                                                    \
         }                                                                                                                                                                \
         else                                                                                                                                                             \
         {                                                                                                                                                                \


### PR DESCRIPTION
## Summary

- Fixed formatting issue in SizeBalancedTree.h by removing one extra space before LeftMaintain(rootIndex) call on line 109
- This improves code consistency and formatting alignment

## Changes

- Removed one space character before `LeftMaintain(rootIndex);` in the DefineUnsafeAttachToTreeMethod macro

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)